### PR TITLE
update serve command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Pull Requests always welcome.
 - [Fork this repository][fork]
 - Clone it: `git clone https://github.com/YOUR-USER/autm-rb`
 - Install the [GitHub Pages gem][pages] (includes Jekyll): `bundle install`
-- Run the jekyll server: `jekyll serve`
+- Run the jekyll server: `bundle exec jekyll serve`
 
 ## Customization
 


### PR DESCRIPTION
When I run `jekyll serve` I got the followings warnings/errors:

```
WARN: Unresolved specs during Gem::Specification.reset:
      posix-spawn (~> 0.3.6)
      redcarpet (~> 3.1)
      listen (~> 2.7)
      classifier-reborn (~> 2.0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
/home/tam/.gem/ruby/2.1.0/gems/jekyll-2.5.3/bin/jekyll:21:in `block in <top (required)>': cannot load such file -- jekyll/version (LoadError)
    from /home/tam/.gem/ruby/2.1.0/gems/mercenary-0.3.5/lib/mercenary.rb:18:in `program'
    from /home/tam/.gem/ruby/2.1.0/gems/jekyll-2.5.3/bin/jekyll:20:in `<top (required)>'
    from /home/tam/.gem/ruby/2.1.0/bin/jekyll:23:in `load'
    from /home/tam/.gem/ruby/2.1.0/bin/jekyll:23:in `<main>'
```

I am not a ruby/jekyll expert but it seems that in this case the Gemfile is not used, which means my jekyll is used (2.5.3) and not the one in the Gemfile (2.4.0) defined by github-pages...

So it might be better to use `bundle exec jekyll serve`
